### PR TITLE
Fix command execution errors

### DIFF
--- a/lua/open_browser_git/command.lua
+++ b/lua/open_browser_git/command.lua
@@ -28,8 +28,6 @@ function M.command(executable, arguments, options)
       .. " failed with exit code "
       .. output.code
       .. "\nError executing: "
-      .. executable
-      .. " "
       .. vim.fn.join(arguments, " ")
     if #output.stdout > 0 then
       message = message .. "\nStdout: " .. output.stdout


### PR DESCRIPTION
They included the executable name twice.