### PR TITLE
Fix `git_repo_root`

### DIFF
--- a/lua/open_browser_git/path.lua
+++ b/lua/open_browser_git/path.lua
@@ -8,7 +8,7 @@ local function git_repo_root(dir)
   return require("open_browser_git.command").git({
     "rev-parse",
     "--show-toplevel",
-  }, { cwd = dir }).stdout[1]
+  }, { cwd = dir }).stdout
 end
 
 -- A path in a Git repository.


### PR DESCRIPTION
I thought, at one point, that `vim.system():wait()` would return an object whose `stdout` field was a list of strings, split by line. This is not true. Maybe it was never true?