### PR TITLE
Find the most recent pushed commit instead of using `HEAD`

### DIFF
--- a/lua/open_browser_git/path.lua
+++ b/lua/open_browser_git/path.lua
@@ -69,12 +69,15 @@ local function tbl_uniq(table, fn)
   return vim.tbl_values(result)
 end
 
---- @param url string
+--- Parse a Git remote URL. The returned `open_browser_git.repo`'s
+--- `remote_name` field will always be `nil`.
+---
+--- @param url string A Git remote URL like `git@github.com:9999years/open-browser-git.nvim.git`.
 --- @return open_browser_git.repo?
 local function parse_git_remote_url(url)
-  -- User, repo, whitespace.
+  -- User, repo.
   -- NB: We trim a trailing `.git` from the repo.
-  local user_repo_pattern = "([^/]+)/([^/]+)%s"
+  local user_repo_pattern = "([^/]+)/([^/]+)$"
   -- NB: We trim a leading `git@` or other username from the hostname.
   local patterns = {
     -- NB: This first pattern also matches ssh://git@... URLs.
@@ -87,31 +90,116 @@ local function parse_git_remote_url(url)
   for _, pattern in ipairs(patterns) do
     local host, user, repo = url:match(pattern)
     if host ~= nil then
-      local remote_name = url:match("^([^\t]+)\t")
       return require("open_browser_git.repo"):new {
         host = host:gsub("^([^@]+)@", ""),
         user = user,
         repo = repo:gsub("%.git$", ""),
-        remote_name = remote_name,
         flavor_patterns = require("open_browser_git")._config.flavor_patterns,
       }
     end
   end
 end
 
+--- Transform a list of Git remote names into parsed `open_browser_git.repo`s.
+---
+--- @param remotes string[]
 --- @return open_browser_git.repo[]
-function Path:list_remotes()
-  local output = self:git { "remote", "-v" }
+function Path:remote_names_to_repos(remotes)
   local repos = {}
-  for line in vim.gsplit(output.stdout, "\n", { plain = true }) do
-    -- Can I simplify this to skip the nil check?
-    local repo = parse_git_remote_url(line)
+  for _, remote in ipairs(remotes) do
+    local repo =
+      parse_git_remote_url(self:git({ "remote", "get-url", remote }).stdout)
     if repo ~= nil then
+      repo.remote_name = remote
       table.insert(repos, repo)
     end
   end
   repos = tbl_uniq(repos, require("open_browser_git.repo").display)
   return repos
+end
+
+--- @class open_browser_git.CommitRemotes
+--- @field commit string
+--- @field remotes string[]
+
+--- Find the nearest commit to `HEAD` (topologically) that is present on at
+--- least one remote.
+---
+--- TODO: Check the blame to find the most accurate commit?
+--- TODO: Traverse the reflog to find pushed commits prior to rebases.
+--- TODO: Offer an option for the user to pick from several commits for e.g.
+--- megamerge workflows.
+---
+--- @return open_browser_git.CommitRemotes?
+function Path:find_remote_commit()
+  -- First, traverse commit ancestors in topological order starting with
+  -- `HEAD`.
+  local commits = vim.gsplit(
+    self:git({
+      "rev-list",
+      -- TODO: Paginate if we can't find a pushed commit. But certainly you're at
+      -- least pushing every 25 commits or so...?
+      "--max-count",
+      "25",
+      "--topo-order",
+      "HEAD",
+    }).stdout,
+    "\n",
+    {
+      plain = true,
+      trimempty = true,
+    }
+  )
+
+  for commit in commits do
+    local remotes = self:remotes_for_commit(commit)
+    if #remotes > 0 then
+      return {
+        commit = commit,
+        remotes = remotes,
+      }
+    end
+  end
+
+  return nil
+end
+
+--- Find the Git remotes (by name) that a given commit is present on.
+---
+--- A ref containing the commit must have been fetched from the remote already
+--- for it to show up; this function does not hit the network, it just checks
+--- refs under `refs/remotes/`.
+---
+--- @param commit string
+--- @return string[]
+function Path:remotes_for_commit(commit)
+  local refs = vim.gsplit(
+    self:git({
+      "for-each-ref",
+      "--format",
+      "%(refname:lstrip=2)",
+      "--contains",
+      commit,
+      "refs/remotes/**",
+    }).stdout,
+    "\n",
+    {
+      plain = true,
+      trimempty = true,
+    }
+  )
+
+  local remotes = {}
+
+  for ref in refs do
+    local components = vim.split(ref, "/", { plain = true })
+    if #components > 0 then
+      local remote = components[1]
+      remotes[remote] = true
+    end
+  end
+
+  return vim.tbl_keys(remotes)
 end
 
 return Path


### PR DESCRIPTION
This traverses the commit ancestors in topological order, starting with `HEAD`, until it finds one that's present on some remote ref, or until it inspects 25 commits.

Closes #2