### PR TITLE
Add `copy_git` command

### DIFF
--- a/lua/open_browser_git.lua
+++ b/lua/open_browser_git.lua
@@ -19,10 +19,7 @@ TODO: optional user/repo argument for commands
 
 ]]
 local M = {
-  _config = {
-    create_commands = true,
-    command_prefix = "OpenGit",
-  },
+  _config = {},
 }
 
 --- @param commit string
@@ -50,13 +47,22 @@ function M.pick_remote(commit, repos, callback)
   end
 end
 
--- If the `path` is given, open that file in a browser.
---
--- If the `path` is absent, open the repo's homepage.
---
--- open_git(path: string|nil, options: {lines: {line1: int, line2: int}|nil}|nil)
+--- @class open_browser_git.Info
+--- @field url string
+--- @field path open_browser_git.path
+--- @field relative_to_root string
+--- @field repo open_browser_git.repo
+--- @field commit string
+
+--- Get commit information and a URL for the given path and options and invoke
+--- a callback.
+---
+--- The user may be consulted interactively to resolve the correct remote name.
+---
 --- @param path? string
-function M.open_git(path, options)
+--- @param options? open_browser_git.repo.UrlOptions
+--- @param callback fun(info: open_browser_git.Info)
+function M.get_info(path, options, callback)
   local path_ = require("open_browser_git.path"):new(path)
   local commit_remotes = path_:find_remote_commit()
   if commit_remotes == nil then
@@ -64,15 +70,45 @@ function M.open_git(path, options)
   end
   local repos = path_:remote_names_to_repos(commit_remotes.remotes)
   M.pick_remote(commit_remotes.commit, repos, function(commit, repo)
-    local url = repo:url_for_file(path_:relative_to_root(), commit, options)
-    require("open_browser_git.open_browser").open_url(url)
+    local relative_to_root = path_:relative_to_root()
+    local url = repo:url_for_file(relative_to_root, commit, options)
+    callback {
+      url = url,
+      path = path_,
+      relative_to_root = relative_to_root,
+      repo = repo,
+      commit = commit,
+    }
   end)
 end
 
+--- Open a Git permalink for the given path and options.
+---
+--- @param path? string
+--- @param options? open_browser_git.repo.UrlOptions
+function M.open_git(path, options)
+  M.get_info(path, options, function(info)
+    require("open_browser_git.open_browser").open_url(info.url)
+  end)
+end
+
+--- Copy a Git permalink for the given path and options to the clipboard.
+---
+--- @param path? string
+--- @param options? open_browser_git.repo.UrlOptions
+function M.copy_git(path, options)
+  M.get_info(path, options, function(info)
+    vim.fn.setreg("+", info.url)
+  end)
+end
+
+--- @class open_browser_git.CommandsConfig
+--- @field open string?
+--- @field copy string?
+
 --- @class open_browser_git.Config
 --- @field browser? open_browser_git.open_browser.Browser
---- @field create_commands? boolean = true
---- @field command_prefix? string = "OpenGit"
+--- @field commands? open_browser_git.CommandsConfig|boolean
 --- @field flavor_patterns? { [string]: string[] }
 
 -- Set up open_browser_git.nvim.
@@ -83,20 +119,66 @@ function M.setup(config)
   if M._config.browser ~= nil then
     require("open_browser_git.open_browser").setup(config)
   end
-  if (M._config.create_commands == nil) or M._config.create_commands then
-    local prefix = M._config.command_prefix or "OpenGit"
-    vim.api.nvim_create_user_command(prefix, function(args)
-      local opts = {}
-      if args.range > 0 then
-        opts.lines = { line1 = args.line1, line2 = args.line2 }
-      end
-      M.open_git(args.args, opts)
-    end, {
-      complete = "file",
-      desc = "",
-      nargs = "?", -- 0 or 1.
-      range = true, -- Default current line.
-    })
+
+  if M._config.command_prefix ~= nil then
+    vim.notify(
+      '`command_prefix` is ignored as of 2025-08-14, use `commands = { open = "OpenGit" }` instead',
+      vim.log.levels.WARN
+    )
+  end
+
+  if M._config.create_commands ~= nil then
+    vim.notify(
+      "`create_commands` is ignored as of 2025-08-14, use `commands = true` instead",
+      vim.log.levels.WARN
+    )
+  end
+
+  if (M._config.commands == nil) or M._config.commands ~= false then
+    local commands = M._config.commands
+    if type(commands) == "boolean" then
+      commands = {}
+    elseif commands == nil then
+      commands = {}
+    end
+
+    if commands.open ~= false then
+      vim.api.nvim_create_user_command(
+        commands.open or "OpenGit",
+        function(args)
+          local opts = {}
+          if args.range > 0 then
+            opts.lines = { line1 = args.line1, line2 = args.line2 }
+          end
+          M.open_git(args.args, opts)
+        end,
+        {
+          complete = "file",
+          desc = "Open a permalink to the current file/line in your browser",
+          nargs = "?", -- 0 or 1.
+          range = true, -- Default current line.
+        }
+      )
+    end
+
+    if commands.copy ~= false then
+      vim.api.nvim_create_user_command(
+        commands.copy or "CopyGit",
+        function(args)
+          local opts = {}
+          if args.range > 0 then
+            opts.lines = { line1 = args.line1, line2 = args.line2 }
+          end
+          M.copy_git(args.args, opts)
+        end,
+        {
+          complete = "file",
+          desc = "Copy a permalink to the current file/line to your clipboard",
+          nargs = "?", -- 0 or 1.
+          range = true, -- Default current line.
+        }
+      )
+    end
   end
 end
 

--- a/lua/open_browser_git/path.lua
+++ b/lua/open_browser_git/path.lua
@@ -13,7 +13,7 @@ end
 
 -- A path in a Git repository.
 --
---- @param path? string
+--- @param path? string Defaults to the current file's directory.
 --- @return open_browser_git.path
 function Path:new(path)
   if (path == nil) or (path == "") then


### PR DESCRIPTION
A new `commands.copy` config setting has been added, which defaults to `CopyGit`. This command, backed by
`require("open_browser_git").copy_git`, will copy the URL directly to the clipboard instead of opening it in a browser for you to copy.

This changes the config format from this:

```
require("open_browser_git").setup {
  create_commands = true,
  command_prefix = "OpenGit",
}
```

```
require("open_browser_git").setup {
  commands = {
    open = "Browse",
  },
}
```

*I* still think that @lf- is underrating the `:OpenGit` command, because it tells you if the link will 404 (shouldn't happen now that #19 is merged) or if the link contains different code than what you're looking at locally (still possible), but Jade gets what she wants ;)

Closes #18