### PR TITLE
open_browser_git.path -> open_browser_git.Path

### DIFF
--- a/lua/open_browser_git.lua
+++ b/lua/open_browser_git.lua
@@ -49,7 +49,7 @@ end
 
 --- @class open_browser_git.Info
 --- @field url string
---- @field path open_browser_git.path
+--- @field path open_browser_git.Path
 --- @field relative_to_root string
 --- @field repo open_browser_git.repo
 --- @field commit string

--- a/lua/open_browser_git/path.lua
+++ b/lua/open_browser_git/path.lua
@@ -1,4 +1,4 @@
---- @class open_browser_git.path
+--- @class open_browser_git.Path
 ---
 --- @field path string
 --- @field repo_root string
@@ -14,7 +14,7 @@ end
 -- A path in a Git repository.
 --
 --- @param path? string Defaults to the current file's directory.
---- @return open_browser_git.path
+--- @return open_browser_git.Path
 function Path:new(path)
   if (path == nil) or (path == "") then
     path = vim.fn.expand("%:p")


### PR DESCRIPTION
This makes the type name `TitleCase` to match the other types, but unfortunately kicks it out of sync from the module name. Oh well!