### PR TITLE
`open_browser_git.repo` → `open_browser_git.Repo`

### DIFF
--- a/lua/open_browser_git.lua
+++ b/lua/open_browser_git.lua
@@ -23,8 +23,8 @@ local M = {
 }
 
 --- @param commit string
---- @param repos open_browser_git.repo[]
---- @param callback fun(commit: string, item: open_browser_git.repo)
+--- @param repos open_browser_git.Repo[]
+--- @param callback fun(commit: string, item: open_browser_git.Repo)
 function M.pick_remote(commit, repos, callback)
   if #repos == 0 then
     error("No Git repos detected from `git remote -v` output")
@@ -51,7 +51,7 @@ end
 --- @field url string
 --- @field path open_browser_git.path
 --- @field relative_to_root string
---- @field repo open_browser_git.repo
+--- @field repo open_browser_git.Repo
 --- @field commit string
 
 --- Get commit information and a URL for the given path and options and invoke

--- a/lua/open_browser_git/path.lua
+++ b/lua/open_browser_git/path.lua
@@ -69,11 +69,11 @@ local function tbl_uniq(table, fn)
   return vim.tbl_values(result)
 end
 
---- Parse a Git remote URL. The returned `open_browser_git.repo`'s
+--- Parse a Git remote URL. The returned `open_browser_git.Repo`'s
 --- `remote_name` field will always be `nil`.
 ---
 --- @param url string A Git remote URL like `git@github.com:9999years/open-browser-git.nvim.git`.
---- @return open_browser_git.repo?
+--- @return open_browser_git.Repo?
 local function parse_git_remote_url(url)
   -- User, repo.
   -- NB: We trim a trailing `.git` from the repo.
@@ -100,10 +100,10 @@ local function parse_git_remote_url(url)
   end
 end
 
---- Transform a list of Git remote names into parsed `open_browser_git.repo`s.
+--- Transform a list of Git remote names into parsed `open_browser_git.Repo`s.
 ---
 --- @param remotes string[]
---- @return open_browser_git.repo[]
+--- @return open_browser_git.Repo[]
 function Path:remote_names_to_repos(remotes)
   local repos = {}
   for _, remote in ipairs(remotes) do

--- a/lua/open_browser_git/repo.lua
+++ b/lua/open_browser_git/repo.lua
@@ -24,7 +24,7 @@
 -- This is all speculation; I don't actually need anything past GitHub and
 -- GitLab support right now. Time and user feedback will tell :)
 --
---- @class open_browser_git.repo: open_browser_git.repo.Options
+--- @class open_browser_git.Repo: open_browser_git.repo.Options
 ---
 --- @field flavor string
 local Repo = {}
@@ -44,9 +44,9 @@ local Repo = {}
 -- `flavor_patterns` is a table mapping flavors to lists of patterns.
 --
 --- @param options open_browser_git.repo.Options
---- @return open_browser_git.repo
+--- @return open_browser_git.Repo
 function Repo:new(options)
-  --- @class open_browser_git.repo
+  --- @class open_browser_git.Repo
   local result = options
   if result.host:find("gitlab") then
     result.flavor = "gitlab"


### PR DESCRIPTION
This makes the type name `TitleCase` to match the other types, but unfortunately kicks it out of sync from the module name. Oh well!